### PR TITLE
use the correct field (hello) in the GraphQL sample

### DIFF
--- a/content/servlet/getting-started/index.md
+++ b/content/servlet/getting-started/index.md
@@ -121,7 +121,7 @@ In this case the URL to post the GraphQL query to is http://localhost:8080/graph
 The following GraphQL query is what the example implementation supports:
 ```gradle
 query {
-    test
+    hello
 }
 ```
 Our Hello Servlet will respond with:


### PR DESCRIPTION
Since the field in the _Query_ `schema` is called `hello`, I think in the sample the field used should be also called `hello` like in

![screenshot from 2019-01-18 15-32-19](https://user-images.githubusercontent.com/436605/51392743-47e6c200-1b36-11e9-9fc6-0b3510380803.png)
