### PR TITLE
Add `ENUM_VALUE` to supported directive locations

### DIFF
--- a/content/tools/directives/index.md
+++ b/content/tools/directives/index.md
@@ -67,10 +67,10 @@ Support for directives is currently limited to the following locations:
 * `INTERFACE`
 * `UNION`
 * `ENUM`
+* `ENUM_VALUE`
 * `INPUT_OBJECT`
 * `INPUT_FIELD_DEFINITION`
 
 Meaning directives for the following locations are currently not yet supported:
 
 * `SCALAR`
-* `ENUM_VALUE`


### PR DESCRIPTION
Documentation seemed a bit out of date considering the conversation that took place in:
https://github.com/graphql-java-kickstart/graphql-java-tools/issues/166#issuecomment-440773466

