### PR TITLE
Feature/doc updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # [GraphQL Java Kickstart Documentation](https://www.graphql-java-kickstart.com/)
-[![Build Status](https://travis-ci.org/graphql-java-kickstart/documentation.svg?branch=master)](https://travis-ci.org/graphql-java-kickstart/documentation)
-[![GitHub contributors](https://img.shields.io/github/contributors/graphql-java-kickstart/documentation)](https://img.shields.io/github/contributors/graphql-java-kickstart/documentation)
+
+
+[![Maven Central](https://img.shields.io/maven-central/v/com.graphql-java-kickstart/graphql-spring-boot-starter.svg)](https://img.shields.io/maven-central/v/com.graphql-java-kickstart/graphql-spring-boot-starter.svg)
+[![GitHub CI Workflow](https://github.com/graphql-java-kickstart/documentation/actions/workflows/publish.yml/badge.svg?branch=master)](https://github.com/graphql-java-kickstart/documentation/actions/workflows/publish.yml?query=branch%3Amaster)
+[![GitHub contributors](https://img.shields.io/github/contributors/graphql-java-kickstart/documentation)](https://img.shields.io/github/contributors/graphql-java-kickstart/graphql-spring-boot)
+[![Discuss on GitHub](https://img.shields.io/badge/GitHub-discuss-orange)](https://github.com/graphql-java-kickstart/graphql-spring-boot/discussions)
+
+
 
 ## We are looking for contributors!
 Are you interested in improving our documentation, working on the codebase, reviewing PRs?

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # [GraphQL Java Kickstart Documentation](https://www.graphql-java-kickstart.com/)
 [![Build Status](https://travis-ci.org/graphql-java-kickstart/documentation.svg?branch=master)](https://travis-ci.org/graphql-java-kickstart/documentation)
-[![Chat on Spectrum](https://img.shields.io/badge/spectrum-join%20the%20community-%23800080)](https://spectrum.chat/graphql-java-kick)
+[![GitHub contributors](https://img.shields.io/github/contributors/graphql-java-kickstart/documentation)](https://img.shields.io/github/contributors/graphql-java-kickstart/documentation)
 
 ## We are looking for contributors!
 Are you interested in improving our documentation, working on the codebase, reviewing PRs?
 
-[Reach out to us on Spectrum](https://spectrum.chat/graphql-java-kick) and join the team!
+[Reach out to us on Discussions](https://github.com/graphql-java-kickstart/graphql-spring-boot/discussions)
+and join the team!
 
 ## Running the site locally
 1. Clone this repository

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # [GraphQL Java Kickstart Documentation](https://www.graphql-java-kickstart.com/)
 
 
-[![Maven Central](https://img.shields.io/maven-central/v/com.graphql-java-kickstart/graphql-spring-boot-starter.svg)](https://img.shields.io/maven-central/v/com.graphql-java-kickstart/graphql-spring-boot-starter.svg)
 [![GitHub CI Workflow](https://github.com/graphql-java-kickstart/documentation/actions/workflows/publish.yml/badge.svg?branch=master)](https://github.com/graphql-java-kickstart/documentation/actions/workflows/publish.yml?query=branch%3Amaster)
-[![GitHub contributors](https://img.shields.io/github/contributors/graphql-java-kickstart/documentation)](https://img.shields.io/github/contributors/graphql-java-kickstart/graphql-spring-boot)
+[![GitHub contributors](https://img.shields.io/github/contributors/graphql-java-kickstart/documentation)](https://github.com/graphql-java-kickstart/documentation/graphs/contributors)
 [![Discuss on GitHub](https://img.shields.io/badge/GitHub-discuss-orange)](https://github.com/graphql-java-kickstart/graphql-spring-boot/discussions)
 
 

--- a/config.toml
+++ b/config.toml
@@ -49,6 +49,16 @@ googleAnalytics = ""
 		url = "https://github.com/graphql-java-kickstart/graphql-spring-boot"
 		menu = "Spring Boot"
 
+  [[params.repositories]]
+    name = "graphql-java-kickstart/graphql-spring-webclient"
+    url = "https://github.com/graphql-java-kickstart/graphql-spring-webclient"
+    menu = "Web Client"
+
+  [[params.repositories]]
+    name = "graphql-java-kickstart/samples"
+    url = "https://github.com/graphql-java-kickstart/samples"
+    menu = "Samples"
+
 	[params.logo]
 		icon = ""
 		image = "images/logo-graphql-kickstart-2000px.png"
@@ -82,6 +92,16 @@ googleAnalytics = ""
 	name   = "Spring Boot"
 	url    = "/spring-boot/"
 	weight = 30
+
+[[menu.main]]
+	name   = "Web Client"
+	url    = "/web-client/"
+	weight = 40
+
+[[menu.main]]
+	name   = "Samples"
+	url    = "/samples/"
+	weight = 50
 
 [blackfriday]
 	smartypants	= true

--- a/config.toml
+++ b/config.toml
@@ -59,6 +59,11 @@ googleAnalytics = ""
     url = "https://github.com/graphql-java-kickstart/samples"
     menu = "Samples"
 
+  [[params.repositories]]
+    name = "philip-jvm/learn-spring-boot-graphql"
+    url = "https://github.com/philip-jvm/learn-spring-boot-graphql"
+    menu = "Tutorials"
+
 	[params.logo]
 		icon = ""
 		image = "images/logo-graphql-kickstart-2000px.png"
@@ -102,6 +107,11 @@ googleAnalytics = ""
 	name   = "Samples"
 	url    = "/samples/"
 	weight = 50
+
+[[menu.main]]
+	name   = "Tutorials"
+	url    = "/tutorials/"
+	weight = 60
 
 [blackfriday]
 	smartypants	= true

--- a/content/samples/_index.md
+++ b/content/samples/_index.md
@@ -1,0 +1,16 @@
+---
+date: 2021-04-09T17:50:13+01:00
+title: About GraphQL Kickstart Samples
+weight: 1
+type: index
+menu:
+  main:
+    parent: Samples
+---
+
+[![GitHub contributors](https://img.shields.io/github/contributors/graphql-java-kickstart/samples)](https://github.com/graphql-java-kickstart/samples/graphs/contributors)
+[![Discuss on GitHub](https://img.shields.io/badge/GitHub-discuss-orange)](https://github.com/graphql-java-kickstart/samples/discussions)
+
+## Overview
+
+You can find a collection of samples projects within the [graphql-java-kickstart/samples](https://github.com/graphql-java-kickstart/samples) repository 

--- a/content/servlet/_index.md
+++ b/content/servlet/_index.md
@@ -8,10 +8,10 @@ menu:
     parent: Servlet
 ---
 
-[![Maven Central](https://img.shields.io/maven-central/v/com.graphql-java-kickstart/graphql-java-servlet.svg)](https://img.shields.io/maven-central/v/com.graphql-java-kickstart/graphql-java-servlet.svg)
-[![GitHub CI Workflow](https://github.com/graphql-java-kickstart/graphql-java-servlet/workflows/ci/badge.svg)](https://github.com/graphql-java-kickstart/graphql-java-servlet/actions?query=workflow%3ACI+branch%3Amaster)
+[![Maven Central](https://img.shields.io/maven-central/v/com.graphql-java-kickstart/graphql-java-servlet.svg)](https://maven-badges.herokuapp.com/maven-central/com.graphql-java-kickstart/graphql-java-servlet)
+[![GitHub CI Workflow](https://github.com/graphql-java-kickstart/graphql-java-servlet/actions/workflows/snapshot.yml/badge.svg?branch=master)](https://github.com/graphql-java-kickstart/graphql-java-servlet/actions/workflows/snapshot.yml)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=graphql-java-kickstart_graphql-java-servlet&metric=alert_status)](https://sonarcloud.io/dashboard?id=graphql-java-kickstart_graphql-java-servlet)
-[![GitHub contributors](https://img.shields.io/github/contributors/graphql-java-kickstart/graphql-java-servlet)](https://img.shields.io/github/contributors/graphql-java-kickstart/graphql-java-servlet)
+[![GitHub contributors](https://img.shields.io/github/contributors/graphql-java-kickstart/graphql-java-servlet)](https://github.com/graphql-java-kickstart/graphql-java-servlet/graphs/contributors)
 [![Discuss on GitHub](https://img.shields.io/badge/GitHub-discuss-orange)](https://github.com/graphql-java-kickstart/graphql-java-servlet/discussions)
 
 

--- a/content/servlet/_index.md
+++ b/content/servlet/_index.md
@@ -8,6 +8,13 @@ menu:
     parent: Servlet
 ---
 
+[![Maven Central](https://img.shields.io/maven-central/v/com.graphql-java-kickstart/graphql-java-servlet.svg)](https://img.shields.io/maven-central/v/com.graphql-java-kickstart/graphql-java-servlet.svg)
+[![GitHub CI Workflow](https://github.com/graphql-java-kickstart/graphql-java-servlet/workflows/ci/badge.svg)](https://github.com/graphql-java-kickstart/graphql-java-servlet/actions?query=workflow%3ACI+branch%3Amaster)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=graphql-java-kickstart_graphql-java-servlet&metric=alert_status)](https://sonarcloud.io/dashboard?id=graphql-java-kickstart_graphql-java-servlet)
+[![GitHub contributors](https://img.shields.io/github/contributors/graphql-java-kickstart/graphql-java-servlet)](https://img.shields.io/github/contributors/graphql-java-kickstart/graphql-java-servlet)
+[![Discuss on GitHub](https://img.shields.io/badge/GitHub-discuss-orange)](https://github.com/graphql-java-kickstart/graphql-java-servlet/discussions)
+
+
 Implementation of GraphQL Java Servlet including support for Relay.js, Apollo and OSGi out of the box.
 This project wraps the Java implementation of GraphQL provided by [GraphQL Java](https://www.graphql-java.com).
 The documentation on this site focuses around the usage of the servlet. Although some parts may dive deeper
@@ -15,7 +22,7 @@ into the aspects of GraphQL Java as well, make sure to look at the
 [GraphQL Java documentation](https://www.graphql-java.com/documentation/latest/) for more in depth details
 regarding GraphQL Java itself.
 
-We try to stay up to date with GraphQL Java as much as possible. The current version supports **GraphQL Java 14.0**.
+We try to stay up to date with GraphQL Java as much as possible. The current version supports **GraphQL Java 16.1**.
 
 This project requires at least Java 8.
 
@@ -37,7 +44,7 @@ repositories {
 Add the `graphql-java-servlet` dependency:
 ```gradle
 dependencies {
-    compile 'com.graphql-java-kickstart:graphql-java-servlet:9.1.0'
+    compile 'com.graphql-java-kickstart:graphql-java-servlet:11.1.0'
 }
 ```
 
@@ -48,7 +55,7 @@ Add the `graphql-java-servlet` dependency:
 <dependency>
   <groupId>com.graphql-java-kickstart</groupId>
   <artifactId>graphql-java-servlet</artifactId>
-  <version>9.1.0</version>
+  <version>11.1.0</version>
 </dependency>
 ```
 

--- a/content/servlet/getting-started/index.md
+++ b/content/servlet/getting-started/index.md
@@ -30,11 +30,10 @@ plugins {
 
 repositories {
     mavenCentral()
-    jcenter()
 }
 
 dependencies {
-    compile 'com.graphql-java-kickstart:graphql-java-servlet:9.1.0'
+    compile 'com.graphql-java-kickstart:graphql-java-servlet:11.1.0'
 }
 ```
 
@@ -53,7 +52,7 @@ Add the `graphql-java-servlet` dependency to your `dependencies` section:
 <dependency>
   <groupId>com.graphql-java-kickstart</groupId>
   <artifactId>graphql-java-servlet</artifactId>
-  <version>9.1.0</version>
+  <version>11.1.0</version>
 </dependency>
 ```
 

--- a/content/spring-boot/_index.md
+++ b/content/spring-boot/_index.md
@@ -7,6 +7,13 @@ menu:
     parent: Spring Boot
 ---
 
+[![Maven Central](https://img.shields.io/maven-central/v/com.graphql-java-kickstart/graphql-spring-boot-starter.svg)](https://img.shields.io/maven-central/v/com.graphql-java-kickstart/graphql-spring-boot-starter.svg)
+[![GitHub CI Workflow](https://github.com/graphql-java-kickstart/graphql-spring-boot/workflows/ci/badge.svg)](https://github.com/graphql-java-kickstart/graphql-spring-boot/actions?query=workflow%3ACI+branch%3Amaster)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=graphql-java-kickstart_graphql-spring-boot&metric=alert_status)](https://sonarcloud.io/dashboard?id=graphql-java-kickstart_graphql-spring-boot)
+[![GitHub contributors](https://img.shields.io/github/contributors/graphql-java-kickstart/graphql-spring-boot)](https://img.shields.io/github/contributors/graphql-java-kickstart/graphql-spring-boot)
+[![Discuss on GitHub](https://img.shields.io/badge/GitHub-discuss-orange)](https://github.com/graphql-java-kickstart/graphql-spring-boot/discussions)
+
+
 This library contains various Spring Boot starters to enable GraphQL related
 services or features.
 
@@ -22,6 +29,10 @@ and [GraphQL-Java Annotations](https://github.com/Enigmatis/graphql-java-annotat
 
 * **graphiql-spring-boot-starter**: embeds the **GraphiQL** tool for schema
 introspection and query debugging (see [GraphiQL](https://github.com/graphql/graphiql))
+
+* **playground-spring-boot-starter**: embeds the **GraphQL Playground** tool for schema
+  introspection and query debugging (see [GraphQL Playground](https://github.com/prisma/graphql-playground))
+
 
 * **graphql-spring-boot-starter-test**: adds testing capabilities to your project,
 like the `@GraphQLTest` annotation which is comparable to `@SpringBootTest`

--- a/content/spring-boot/_index.md
+++ b/content/spring-boot/_index.md
@@ -7,10 +7,10 @@ menu:
     parent: Spring Boot
 ---
 
-[![Maven Central](https://img.shields.io/maven-central/v/com.graphql-java-kickstart/graphql-spring-boot-starter.svg)](https://img.shields.io/maven-central/v/com.graphql-java-kickstart/graphql-spring-boot-starter.svg)
-[![GitHub CI Workflow](https://github.com/graphql-java-kickstart/graphql-spring-boot/workflows/ci/badge.svg)](https://github.com/graphql-java-kickstart/graphql-spring-boot/actions?query=workflow%3ACI+branch%3Amaster)
+[![Maven Central](https://img.shields.io/maven-central/v/com.graphql-java-kickstart/graphql-spring-boot-starter.svg)](https://maven-badges.herokuapp.com/maven-central/com.graphql-java-kickstart/graphql-spring-boot-starter)
+[![GitHub CI Workflow](https://github.com/graphql-java-kickstart/graphql-spring-boot/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/graphql-java-kickstart/graphql-spring-boot/actions/workflows/ci.yml?query=workflow%3ACI+branch%3Amaster)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=graphql-java-kickstart_graphql-spring-boot&metric=alert_status)](https://sonarcloud.io/dashboard?id=graphql-java-kickstart_graphql-spring-boot)
-[![GitHub contributors](https://img.shields.io/github/contributors/graphql-java-kickstart/graphql-spring-boot)](https://img.shields.io/github/contributors/graphql-java-kickstart/graphql-spring-boot)
+[![GitHub contributors](https://img.shields.io/github/contributors/graphql-java-kickstart/graphql-spring-boot)](https://github.com/graphql-java-kickstart/graphql-spring-boot/graphs/contributors)
 [![Discuss on GitHub](https://img.shields.io/badge/GitHub-discuss-orange)](https://github.com/graphql-java-kickstart/graphql-spring-boot/discussions)
 
 

--- a/content/spring-boot/getting-started/index.md
+++ b/content/spring-boot/getting-started/index.md
@@ -30,10 +30,10 @@ repositories {
 Add the respective starter dependencies you want to use:
 ```gradle
 dependencies {
-    compile 'com.graphql-java-kickstart:graphql-spring-boot-starter:7.0.1'
-    compile 'com.graphql-java-kickstart:graphiql-spring-boot-starter:7.0.1'
-    compile 'com.graphql-java-kickstart:voyager-spring-boot-starter:7.0.1'
-    testCompile 'com.graphql-java-kickstart:graphql-spring-boot-starter-test:7.0.1'
+    compile 'com.graphql-java-kickstart:graphql-spring-boot-starter:11.0.0'
+    compile 'com.graphql-java-kickstart:graphiql-spring-boot-starter:11.0.0'
+    compile 'com.graphql-java-kickstart:voyager-spring-boot-starter:11.0.0'
+    testCompile 'com.graphql-java-kickstart:graphql-spring-boot-starter-test:11.0.0'
 }
 ```
 
@@ -44,29 +44,34 @@ Add the respective starter dependencies you want to use:
 <dependency>
   <groupId>com.graphql-java-kickstart</groupId>
   <artifactId>graphql-spring-boot-starter</artifactId>
-  <version>7.0.1</version>
+  <version>11.0.0</version>
 </dependency>
 <dependency>
   <groupId>com.graphql-java-kickstart</groupId>
   <artifactId>graphiql-spring-boot-starter</artifactId>
-  <version>7.0.1</version>
+  <version>11.0.0</version>
+</dependency>
+<dependency>
+  <groupId>com.graphql-java-kickstart</groupId>
+  <artifactId>playground-spring-boot-starter</artifactId>
+  <version>11.0.0</version>
 </dependency>
 <dependency>
   <groupId>com.graphql-java-kickstart</groupId>
   <artifactId>voyager-spring-boot-starter</artifactId>
-  <version>7.0.1</version>
+  <version>11.0.0</version>
 </dependency>
 <dependency>
   <groupId>com.graphql-java-kickstart</groupId>
   <artifactId>graphql-spring-boot-starter-test</artifactId>
-  <version>7.0.1</version>
+  <version>11.0.0</version>
   <scope>test</scope>
 </dependency>
 ```
 
 ## Using the latest development build
 
-Snapshot versions of the current `master` branch are availble on JFrog. Check the next snapshot version on
+Snapshot versions of the current `master` branch are available on JFrog. Check the next snapshot version on
 [Github](https://github.com/graphql-java-kickstart/graphql-java-tools/blob/master/gradle.properties)
 
 ### Build with Gradle

--- a/content/tools/_index.md
+++ b/content/tools/_index.md
@@ -8,10 +8,10 @@ menu:
     parent: Tools
 ---
 
-[![Maven Central](https://img.shields.io/maven-central/v/com.graphql-java-kickstart/graphql-java-tools.svg)](https://img.shields.io/maven-central/v/com.graphql-java-kickstart/graphql-java-tools.svg)
+[![Maven Central](https://img.shields.io/maven-central/v/com.graphql-java-kickstart/graphql-java-tools.svg)](https://maven-badges.herokuapp.com/maven-central/com.graphql-java-kickstart/graphql-java-tools)
 [![TravisCI Build](https://travis-ci.org/graphql-java-kickstart/graphql-java-tools.svg?branch=master)](https://travis-ci.org/graphql-java-kickstart/graphql-java-tools)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=graphql-java-kickstart_graphql-java-tools&metric=alert_status)](https://sonarcloud.io/dashboard?id=graphql-java-kickstart_graphql-java-tools)
-[![GitHub contributors](https://img.shields.io/github/contributors/graphql-java-kickstart/graphql-java-tools)](https://img.shields.io/github/contributors/graphql-java-kickstart/graphql-java-tools)
+[![GitHub contributors](https://img.shields.io/github/contributors/graphql-java-kickstart/graphql-java-tools)](https://github.com/graphql-java-kickstart/graphql-java-tools/graphs/contributors)
 [![Discuss on GitHub](https://img.shields.io/badge/GitHub-discuss-orange)](https://github.com/graphql-java-kickstart/graphql-java-tools/discussions)
 
 This library allows you to use the GraphQL schema language to build your [graphql-java](https://github.com/graphql-java/graphql-java) schema.

--- a/content/tools/_index.md
+++ b/content/tools/_index.md
@@ -8,7 +8,11 @@ menu:
     parent: Tools
 ---
 
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.graphql-java-kickstart/graphql-java-tools/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.graphql-java-kickstart/graphql-java-tools)
+[![Maven Central](https://img.shields.io/maven-central/v/com.graphql-java-kickstart/graphql-java-tools.svg)](https://img.shields.io/maven-central/v/com.graphql-java-kickstart/graphql-java-tools.svg)
+[![TravisCI Build](https://travis-ci.org/graphql-java-kickstart/graphql-java-tools.svg?branch=master)](https://travis-ci.org/graphql-java-kickstart/graphql-java-tools)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=graphql-java-kickstart_graphql-java-tools&metric=alert_status)](https://sonarcloud.io/dashboard?id=graphql-java-kickstart_graphql-java-tools)
+[![GitHub contributors](https://img.shields.io/github/contributors/graphql-java-kickstart/graphql-java-tools)](https://img.shields.io/github/contributors/graphql-java-kickstart/graphql-java-tools)
+[![Discuss on GitHub](https://img.shields.io/badge/GitHub-discuss-orange)](https://github.com/graphql-java-kickstart/graphql-java-tools/discussions)
 
 This library allows you to use the GraphQL schema language to build your [graphql-java](https://github.com/graphql-java/graphql-java) schema.
 Inspired by [graphql-tools](https://github.com/apollographql/graphql-tools), it parses the given GraphQL schema and allows you to BYOO (bring your own object) to fill in the implementations.

--- a/content/tools/getting-started/index.md
+++ b/content/tools/getting-started/index.md
@@ -32,7 +32,7 @@ repositories {
 Add the `graphql-java-tools` dependency:
 ```gradle
 dependencies {
-    compile 'com.graphql-java-kickstart:graphql-java-tools:6.0.2'
+    compile 'com.graphql-java-kickstart:graphql-java-tools:11.0.0'
 }
 ```
 
@@ -43,7 +43,7 @@ Add the `graphql-java-tools` dependency:
 <dependency>
   <groupId>com.graphql-java-kickstart</groupId>
   <artifactId>graphql-java-tools</artifactId>
-  <version>6.0.2</version>
+  <version>11.0.0</version>
 </dependency>
 ```
 

--- a/content/tutorials/_index.md
+++ b/content/tutorials/_index.md
@@ -1,0 +1,20 @@
+---
+date: 2021-04-09T17:50:13+01:00
+title: About Learn GraphQL Spring Boot
+weight: 1
+type: index
+menu:
+  main:
+    parent: Tutorials
+
+---
+
+## Learn GraphQL Spring Boot Course
+
+[Philip Starritt](https://github.com/philip-jvm) has published an excellent tutorial series on YouTube, which provides a hands-on approach to learning GraphQL Spring Boot.
+
+You can also find the implementation examples from the tutorial series at [philip-jvm/learn-spring-boot-graphql](https://github.com/philip-jvm/learn-spring-boot-graphql)
+
+
+## Playlist
+Check out the full [Spring Boot GraphQL Tutorial YouTube Playlist](https://www.youtube.com/playlist?list=PLiwhu8iLxKwL1TU0RMM6z7TtkyW-3-5Wi) for the latest set of videos

--- a/content/tutorials/courses/_index.md
+++ b/content/tutorials/courses/_index.md
@@ -1,0 +1,141 @@
+---
+date: 2021-04-09T17:50:13+01:00
+title: Courses
+weight: 1
+type: index
+menu:
+  main:
+    identifier: tutorial-courses
+    parent: Tutorials
+    url: /tutorials/courses/
+---
+
+
+## 1 - Introduction, Dependencies, IDE Setup
+{{< youtube id="nju6jFW8CVw" >}}
+{{< youtube-badges id="nju6jFW8CVw" playlistIndex="1" >}}
+
+## 2 - Creating your first Schema and Query
+{{< youtube id="rH2kdMPUQpQ" >}}
+{{< youtube-badges id="rH2kdMPUQpQ" playlistIndex="2" >}}
+
+
+## 3 - Schema Design Best Practices
+{{< youtube id="zc3KHikd9ko" >}}
+{{< youtube-badges id="zc3KHikd9ko" playlistIndex="3" >}}
+
+## 4 - DDOS, Recursion, Max Query Depth Limit
+{{< youtube id="JRh5Rd6Reis" >}}
+{{< youtube-badges id="JRh5Rd6Reis" playlistIndex="4" >}}
+
+## 5 - Playground GraphQL IDE
+{{< youtube id="4bheCHi5zKs" >}}
+{{< youtube-badges id="4bheCHi5zKs" playlistIndex="5" >}}
+
+## 6 - Voyager Schema Visualizer
+{{< youtube id="46zhRqEuvBI" >}}
+{{< youtube-badges id="46zhRqEuvBI" playlistIndex="6" >}}
+
+## 7 - Resolvers
+{{< youtube id="Lmwqb7BGtQ0" >}}
+{{< youtube-badges id="Lmwqb7BGtQ0" playlistIndex="7" >}}
+
+## 8 - Exception Handling with ExceptionHandler
+{{< youtube id="p3mA1OQg1kc" >}}
+{{< youtube-badges id="p3mA1OQg1kc" playlistIndex="8" >}}
+
+## 9 - Exception Handling with GraphQLErrorHandler
+{{< youtube id="bbfsak5i8Ok" >}}
+{{< youtube-badges id="bbfsak5i8Ok" playlistIndex="9" >}}
+
+## 10 - DataFetcherResult - Returning data and errors
+{{< youtube id="zjT9Jy276" >}}
+{{< youtube-badges id="zjT9Jy276" playlistIndex="10" >}}
+
+## 11 - Asynchronous Resolvers
+{{< youtube id="UOyIQCsVii4" >}}
+{{< youtube-badges id="UOyIQCsVii4" playlistIndex="11" >}}
+
+## 12 - Mutation
+{{< youtube id="NR0HwkLhWAk" >}}
+{{< youtube-badges id="NR0HwkLhWAk" playlistIndex="12" >}}
+
+## 13 - File Upload
+{{< youtube id="8SDGusSKV1o" >}}
+{{< youtube-badges id="8SDGusSKV1o" playlistIndex="13" >}}
+
+## 14 - DataFetchingEnvironment
+{{< youtube id="_sILQm0axSw" >}}
+{{< youtube-badges id="_sILQm0axSw" playlistIndex="14" >}}
+
+## 15 - SelectionSet
+{{< youtube id="9vmKzs1P10I" >}}
+{{< youtube-badges id="9vmKzs1P10I" playlistIndex="15" >}}
+
+## 16 - Custom Scalar
+{{< youtube id="6LGlR-oTN3A" >}}
+{{< youtube-badges id="6LGlR-oTN3A" playlistIndex="16" >}}
+
+## 17 - Date Type
+{{< youtube id="jH5zHnq_0ZQ" >}}
+{{< youtube-badges id="jH5zHnq_0ZQ" playlistIndex="17" >}}
+
+## 18 - Input Validation (Method 1 - Bean)
+{{< youtube id="gmbVyZvGCIE" >}}
+{{< youtube-badges id="gmbVyZvGCIE" playlistIndex="18" >}}
+
+## 20 - Listener
+{{< youtube id="nybkMHHyXUk" >}}
+{{< youtube-badges id="nybkMHHyXUk" playlistIndex="20" >}}
+
+## 21 - Pagination (Edges, Nodes, Cursor)
+{{< youtube id="J9Nq0Fq7t_8" >}}
+{{< youtube-badges id="J9Nq0Fq7t_8" playlistIndex="21" >}}
+
+## 22 - Custom Context
+{{< youtube id="YsM2VSnWUcg" >}}
+{{< youtube-badges id="YsM2VSnWUcg" playlistIndex="22" >}}
+
+## 23 - DataLoader (N+1 problem)
+{{< youtube id="tbxskis_ny4" >}}
+{{< youtube-badges id="tbxskis_ny4" playlistIndex="23" >}}
+
+## 24 - Instrumentation (Request Logging)
+{{< youtube id="fPfApe80amg" >}}
+{{< youtube-badges id="fPfApe80amg" playlistIndex="24" >}}
+
+## 25 - Request Tracing
+{{< youtube id="b5o6w-WA9iM" >}}
+{{< youtube-badges id="b5o6w-WA9iM" playlistIndex="25" >}}
+
+#26 - Correlation ID (Thread propagation)
+{{< youtube id="17AFe2eCRqc" >}}
+{{< youtube-badges id="17AFe2eCRqc" playlistIndex="26" >}}
+
+#27 - Integration Testing (GraphQLTestTemplate)
+{{< youtube id="bdfEjn6xZx0" >}}
+{{< youtube-badges id="bdfEjn6xZx0" playlistIndex="27" >}}
+
+#28 - JS GraphQL IntelliJ Plugin
+{{< youtube id="hFHxOlThFR4" >}}
+{{< youtube-badges id="hFHxOlThFR4" playlistIndex="28" >}}
+
+## 29 – JVM Profiling (VisualVM, JMeter)
+{{< youtube id="Bu-P0aZyOfE" >}}
+{{< youtube-badges id="Bu-P0aZyOfE" playlistIndex="29" >}}
+
+## 30 – DataLoader Key Context
+{{< youtube id="nuRYRRAQh_Y" >}}
+{{< youtube-badges id="nuRYRRAQh_Y" playlistIndex="30" >}}
+
+## 31 – Spring Security
+{{< youtube id="_T_0VB3AoV4" >}}
+{{< youtube-badges id="_T_0VB3AoV4" playlistIndex="31" >}}
+
+## 32 – Schema Directive Validation
+{{< youtube id="DN9XyUZ8yq8" >}}
+{{< youtube-badges id="DN9XyUZ8yq8" playlistIndex="32" >}}
+
+## 33 – Subscription with Reactor
+{{< youtube id="I3NBPHA5coo" >}}
+{{< youtube-badges id="I3NBPHA5coo" playlistIndex="33" >}}

--- a/content/web-client/_index.md
+++ b/content/web-client/_index.md
@@ -1,0 +1,21 @@
+---
+date: 2021-04-09T17:50:13+01:00
+title: About GraphQL Spring WebClient
+weight: 1
+type: index
+menu:
+  main:
+    parent: Web Client
+---
+
+[![Maven Central](https://img.shields.io/maven-central/v/com.graphql-java-kickstart/graphql-webclient-spring-boot-starter.svg)](https://maven-badges.herokuapp.com/maven-central/com.graphql-java-kickstart/graphql-webclient-spring-boot-starter)
+[![GitHub CI Workflow](https://github.com/graphql-java-kickstart/graphql-spring-webclient/actions/workflows/snapshot.yml/badge.svg?branch=master)](https://github.com/graphql-java-kickstart/graphql-spring-webclient/actions/workflows/snapshot.yml?query=branch%3Amaster)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=graphql-java-kickstart_graphql-spring-webclient&metric=alert_status)](https://sonarcloud.io/dashboard?id=graphql-java-kickstart_graphql-spring-webclient)
+[![GitHub contributors](https://img.shields.io/github/contributors/graphql-java-kickstart/graphql-spring-webclient)](https://github.com/graphql-java-kickstart/graphql-spring-webclient/graphs/contributors)
+[![Discuss on GitHub](https://img.shields.io/badge/GitHub-discuss-orange)](https://github.com/graphql-java-kickstart/graphql-spring-webclient/discussions)
+
+## Overview
+
+Reactive GraphQL client for consuming GraphQL APIs from a Spring Boot application. Provides OAuth2 authorization through configuration.
+
+See [README.md](https://github.com/graphql-java-kickstart/graphql-spring-webclient) for more details on configuration options and usage

--- a/themes/hugo-material-docs/layouts/partials/youtube.html
+++ b/themes/hugo-material-docs/layouts/partials/youtube.html
@@ -1,0 +1,5 @@
+<div style="position: relative; padding-bottom: 56.25%; overflow: hidden;">
+  <iframe style="position: absolute; width: 100%; height: 100%;"
+          src="http://www.youtube.com/embed/{{ index .Params 0 }}" allowfullscreen frameborder="0">
+  </iframe>
+</div>

--- a/themes/hugo-material-docs/layouts/shortcodes/youtube-badges.html
+++ b/themes/hugo-material-docs/layouts/shortcodes/youtube-badges.html
@@ -1,0 +1,11 @@
+<div>
+  <a href="https://www.youtube.com/watch?v={{.Get "id"}}&list=PLiwhu8iLxKwL1TU0RMM6z7TtkyW-3-5Wi&index={{.Get "playlistIndex"}}&ab_channel=PhilipStarritt">
+    <img src="https://img.shields.io/youtube/views/{{.Get "id"}}?style=social" />
+  </a>
+  <a href="https://www.youtube.com/watch?v={{.Get "id"}}&list=PLiwhu8iLxKwL1TU0RMM6z7TtkyW-3-5Wi&index={{.Get "playlistIndex"}}&ab_channel=PhilipStarritt">
+    <img src="https://img.shields.io/youtube/likes/{{.Get "id"}}?style=social" />
+  </a>
+  <a href="https://www.youtube.com/watch?v={{.Get "id"}}&list=PLiwhu8iLxKwL1TU0RMM6z7TtkyW-3-5Wi&index={{.Get "playlistIndex"}}&ab_channel=PhilipStarritt">
+    <img src="https://img.shields.io/youtube/comments/{{.Get "id"}}?style=social" />
+  </a>
+</div>


### PR DESCRIPTION
Several updates to the public documentation site, including
* adding badges for each repository
* adding new section for web-client and samples repos
* removing jcenter references
* updating graphql-java supported version reference
* updating latest version numbers in dependency snippets
* removing references to spectrum with github discussions