### PR TITLE
Update documentation on @deprecated directive support

### DIFF
--- a/content/tools/schema-definition/index.md
+++ b/content/tools/schema-definition/index.md
@@ -250,7 +250,7 @@ enum Episode {
 ```
 ## GraphQL Deprecations
 
-GraphQL field/enum deprecations can be provided by the `@deprecated(reason: String)` directive, and are added to the generated schema.
+GraphQL deprecations on output fields, enums, arguments, directive arguments, and input fields can be provided by the `@deprecated(reason: String)` directive, and are added to the generated schema.
 You can either supply a **reason** argument with a string value or not supply one and receive a "No longer supported" message when introspected:
 
 ```graphql


### PR DESCRIPTION
This PR updates the documentation on the `@deprecated` annotation to reflect all of the things that can now be marked as deprecated, once https://github.com/graphql-java-kickstart/graphql-java-tools/pull/696 merges and is included in a release.

This shouldn't be merged until the code in that PR is released.